### PR TITLE
Add steps and degree of precision in sliders

### DIFF
--- a/js/CADWorker/CascadeStudioStandardLibrary.js
+++ b/js/CADWorker/CascadeStudioStandardLibrary.js
@@ -872,10 +872,15 @@ function SaveFile(filename, fileURL) {
   });
 }
 
-function Slider(name = "Val", defaultValue = 0.5, min = 0.0, max = 1.0, realTime=false) {
+function Slider(name = "Val", defaultValue = 0.5, min = 0.0, max = 1.0, realTime=false, step, precision) {
   if (!(name in GUIState)) { GUIState[name] = defaultValue; }
+  if (!step) { step = 0.01; }
+  if (typeof precision === "undefined") {
+    precision = 2;
+  } else if (precision % 1) { console.error("Slider precision must be an integer"); }
+  
   GUIState[name + "Range"] = [min, max];
-  postMessage({ "type": "addSlider", payload: { name: name, default: defaultValue, min: min, max: max, realTime: realTime } });
+  postMessage({ "type": "addSlider", payload: { name: name, default: defaultValue, min: min, max: max, realTime: realTime, step: step, dp: precision } });
   return GUIState[name];
 }
 

--- a/js/MainPage/CascadeMain.js
+++ b/js/MainPage/CascadeMain.js
@@ -439,7 +439,9 @@ function initialize() {
         GUIState[payload.name + "Range"] = [payload.min, payload.max];
         guiPanel.addSlider(GUIState, payload.name, payload.name + 'Range', {
             onFinish: () => { monacoEditor.evaluateCode(); },
-            onChange: () => { if (payload.realTime) { monacoEditor.evaluateCode(); } }
+            onChange: () => { if (payload.realTime) { monacoEditor.evaluateCode(); } },
+            step: payload.step,
+            dp: payload.dp
         });
     }
     messageHandlers["addButton"] = (payload) => {

--- a/js/StandardLibraryIntellisense.ts
+++ b/js/StandardLibraryIntellisense.ts
@@ -7,6 +7,9 @@ var sceneShapes: oc.TopoDS_Shape[];
  * @example```sceneShapes.push(externalShapes['myStep.step']);``` */
 var externalShapes: { [filename: string]: oc.TopoDS_Shape };
 
+/** Type definition for Int */
+type integer = number;
+
 /** Starts sketching a 2D shape which can contain lines, arcs, bezier splines, and fillets.
  * [Source](https://github.com/zalo/CascadeStudio/blob/master/js/CADWorker/CascadeStudioStandardLibrary.js)
  * @example```let sketch = new Sketch([0,0]).LineTo([100,0]).Fillet(20).LineTo([100,100]).End(true).Face();```*/
@@ -129,7 +132,7 @@ function Offset(shape: oc.TopoDS_Shape, offsetDistance: number, tolerance?: numb
  * `name` needs to be unique!
  * 
  * `callback` triggers whenever the mouse is let go, and `realTime` will cause the slider to update every frame that there is movement (but it's buggy!)*/
-function Slider(name: string, defaultValue: number, min: number, max: number, realTime?: boolean): number;
+function Slider(name: string, defaultValue: number, min: number, max: number, realTime?: boolean, step?: number, precision?: integer): number;
 /** Creates a button that will trigger `callback` when clicked.
  * [Source](https://github.com/zalo/CascadeStudio/blob/master/js/CADWorker/CascadeStudioStandardLibrary.js)
  * @example```Button("Yell", ()=>{ console.log("Help!  I've been clicked!"); });```*/

--- a/js/StandardLibraryIntellisense.ts
+++ b/js/StandardLibraryIntellisense.ts
@@ -131,7 +131,15 @@ function Offset(shape: oc.TopoDS_Shape, offsetDistance: number, tolerance?: numb
  * @example```let currentSliderValue = Slider("Radius", 30 , 20 , 40);```
  * `name` needs to be unique!
  * 
- * `callback` triggers whenever the mouse is let go, and `realTime` will cause the slider to update every frame that there is movement (but it's buggy!)*/
+ * `callback` triggers whenever the mouse is let go, and `realTime` will cause the slider to update every frame that there is movement (but it's buggy!)
+ * 
+ * @param step controls the amount that the keyboard arrow keys will increment or decrement a value. Defaults to 1/100 (0.01).
+ * @param precision controls how many decimal places the slider can have (i.e. "0" is integers, "1" includes tenths, etc.). Defaults to 2 decimal places (0.00).
+ * 
+ * @example```let currentSliderValue = Slider("Radius", 30 , 20 , 40, false);```
+ * @example```let currentSliderValue = Slider("Radius", 30 , 20 , 40, false, 0.01);```
+ * @example```let currentSliderValue = Slider("Radius", 30 , 20 , 40, false, 0.01, 2);```
+ */
 function Slider(name: string, defaultValue: number, min: number, max: number, realTime?: boolean, step?: number, precision?: integer): number;
 /** Creates a button that will trigger `callback` when clicked.
  * [Source](https://github.com/zalo/CascadeStudio/blob/master/js/CADWorker/CascadeStudioStandardLibrary.js)


### PR DESCRIPTION
For more precision in modelling gears, etc., I tried implementing ControlKit's steps and dp in Slider.

Had a bit of an issue with Intellisense's definitions. I did not manage to implement Integer type in ts. A possible candidate might be [newtype-ts](https://github.com/gcanti/newtype-ts)'s `Integer`, but I don't really know how to add it to client rendered projects.