### PR TITLE
[FEAT] Use File System Access API to choose file saving locations

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,11 +67,8 @@
         <h1 hidden></h1> <!-- Puts the Lighthouse Score over 90 heheh-->
         <div id="topnav" class="topnav">
             <a href="https://github.com/zalo/CascadeStudio">Cascade Studio 0.0.6</a>
-            <a href="#" id="main-proj-button" title="Sets this project to save in local storage." onmouseup="makeMainProject();">Make Main Project</a>
             <a href="#" title="Save Project to .json" onmouseup="saveProject();">Save Project</a>
-            <label for="project-file" title="Load Project from .json">Load Project
-                <input id="project-file" name="project-file" type="file" accept=".json" style="display:none;" oninput="loadProject();"/>
-            </label>
+            <a href="#" title="Load Project from .json" onmouseup="loadProject();">Load Project</a>
             <a href="#" onmouseup="threejsViewport.saveShapeSTEP();">Save STEP</a>
             <a href="#" onmouseup="threejsViewport.saveShapeSTL();">Save STL</a>
             <a href="#" onmouseup="threejsViewport.saveShapeOBJ();">Save OBJ</a>

--- a/index.html
+++ b/index.html
@@ -76,7 +76,6 @@
                 <input id="files" name="files" type="file" accept=".iges,.step,.igs,.stp,.stl" multiple style="display:none;" oninput="loadFiles();"/>
             </label>
             <a href="#" title="Clears the external step/iges/stl files stored in the project." onmouseup="clearExternalFiles();">Clear Imported Files</a>
-            <a href="" title="Resets the project and localstorage." onmouseup="window.localStorage.clear(); window.history.replaceState({}, 'Cascade Studio','?');">Reset Project</a>
         </div>
         <div id="appbody" style="height:auto">
             <link data-name="vs/editor/editor.main" rel="stylesheet" href="./node_modules/monaco-editor/min/vs/editor/editor.main.css">

--- a/js/CADWorker/CascadeStudioFileUtils.js
+++ b/js/CADWorker/CascadeStudioFileUtils.js
@@ -123,7 +123,7 @@ function importSTL(fileName, fileText) {
   }
 }
 
-/** This function returns `currentShape` as a data URL containing a `.STEP` file.  
+/** This function returns `currentShape` `.STEP` file content.  
  * `currentShape` is set upon the successful completion of `combineAndRenderShapes()`.  */
 function saveShapeSTEP (filename = "CascadeStudioPart.step") {
   let writer = new oc.STEPControl_Writer();
@@ -137,8 +137,8 @@ function saveShapeSTEP (filename = "CascadeStudioPart.step") {
       let stepFileText = oc.FS.readFile("/" + filename, { encoding:"utf8" });
       oc.FS.unlink("/" + filename);
 
-      // Return a data url containing the contents of the STEP File
-      return URL.createObjectURL( new Blob([stepFileText], { type: 'text/plain' }) );
+      // Return the contents of the STEP File
+      return stepFileText;
     }else{
       console.error("WRITE STEP FILE FAILED.");
     }

--- a/js/MainPage/CascadeMain.js
+++ b/js/MainPage/CascadeMain.js
@@ -518,6 +518,9 @@ async function saveProject() {
 
 /** This loads a .json file as the currentProject.*/
 const loadProject = async () => {
+    // Don't allow loading while the worker is working to prevent race conditions.
+    if (workerWorking) { return; }
+
     // Load Project .json from a file
     [file.handle] = await getNewFileHandle(
         'Cascade Studio project files',

--- a/js/MainPage/CascadeMain.js
+++ b/js/MainPage/CascadeMain.js
@@ -32,7 +32,7 @@ Translate([-25, 0, 40], Text3D("Hi!"));
 function initialize(projectContent = null) {
     this.searchParams = new URLSearchParams(window.location.search);
 
-    // Load the initial Project from - URL, or the Gallery
+    // Load the initial Project from - "projectContent", the URL, or the Gallery
     let loadFromURL     = this.searchParams.has("code");
     let loadfromGallery = this.searchParams.has("project");
 

--- a/js/MainPage/CascadeView.js
+++ b/js/MainPage/CascadeView.js
@@ -248,40 +248,39 @@ var CascadeEnvironment = function (goldenContainer) {
   }
 
   /** Save the current shape to .stl */
-  this.saveShapeSTEP = (filename = "CascadeStudioPart.step") => {
+  this.saveShapeSTEP = () => {
     // Ask the worker thread for a STEP file of the current space
-    cascadeStudioWorker.postMessage({
-      "type": "saveShapeSTEP",
-      payload: filename
-    });
+    cascadeStudioWorker.postMessage({"type": "saveShapeSTEP"});
 
-    // Receive the STEP File from the Worker Thread
-    messageHandlers["saveShapeSTEP"] = (stepURL) => {
-      let link      = document.createElement("a");
-      link.href     = stepURL;
-      link.download = filename;
-      link.click();
+    // Receive the STEP file content from the Worker Thread
+    messageHandlers["saveShapeSTEP"] = async (stepContent) => {
+      const fileHandle = await getNewFileHandle("STEP files", "text/plain", "step");
+      writeFile(fileHandle, stepContent).then(() => {
+        console.log("Saved STEP to " + fileHandle.name);
+      });
     };
   }
 
   /**  Save the current shape to an ASCII .stl */
-  this.saveShapeSTL = (filename = "CascadeStudioPart.stl") => {
+  this.saveShapeSTL = async () => {
     this.stlExporter = new THREE.STLExporter();
     let result = this.stlExporter.parse(this.mainObject);
-    let link = document.createElement("a");
-    link.href = URL.createObjectURL( new Blob([result], { type: 'text/plain' }) );
-		link.download = filename;
-		link.click();
+    
+    const fileHandle = await getNewFileHandle("STL files", "text/plain", "stl");
+    writeFile(fileHandle, result).then(() => {
+      console.log("Saved STL to " + fileHandle.name);
+    });
   }
 
   /**  Save the current shape to .obj */
-  this.saveShapeOBJ = (filename = "CascadeStudioPart.obj") => {
+  this.saveShapeOBJ = async () => {
     this.objExporter = new THREE.OBJExporter();
     let result = this.objExporter.parse(this.mainObject);
-    let link = document.createElement("a");
-    link.href = URL.createObjectURL( new Blob([result], { type: 'text/plain' }) );
-		link.download = filename;
-		link.click();
+    
+    const fileHandle = await getNewFileHandle("OBJ files", "text/plain", "obj");
+    writeFile(fileHandle, result).then(() => {
+      console.log("Saved OBJ to " + fileHandle.name);
+    });
   }
 
   /** Set up the the Mouse Move Callback */

--- a/js/MainPage/CascadeView.js
+++ b/js/MainPage/CascadeView.js
@@ -106,6 +106,7 @@ var Environment = function (goldenContainer) {
 
 /** This "inherits" from Environment (by including it as a sub object) */
 var CascadeEnvironment = function (goldenContainer) {
+  this.active          = true;
   this.goldenContainer = goldenContainer;
   this.environment     = new Environment(this.goldenContainer);
 
@@ -291,6 +292,9 @@ var CascadeEnvironment = function (goldenContainer) {
   }, false );
 
   this.animate = function animatethis() {
+    // Don't continue this callback if the View has been destroyed.
+    if (!this.active) { return; }
+    
     requestAnimationFrame(() => this.animate());
     
     // Lightly Highlight the faces of the object and the current face/edge index

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,7 +2,7 @@
 
 /* A version number is useful when updating the worker logic,
    allowing you to remove outdated cache entries during the update. */
-var version = 'v0.0.6.4::';
+var version = 'v0.0.6.5::';
 
 /* These resources will be downloaded and cached by the service worker
    during the installation process. If any resource fails to be downloaded,


### PR DESCRIPTION
@zalo Here's what I've come up with for #30. The changes:

* Save the project to a file of your choosing
* Implement the Ctrl+S keyboard shortcut to save the project. If we have already saved, this automatically re-saves to the same file as before
* Change the title of the code editor to the filename, with a `*` if the code has changed since the last save
* Automatically Evaluate the code on save, just like OpenSCAD does
* There were some conflicts with the "Make Main Project" feature so I removed it since it seems unecessary at this point
* Keep track of the file handler when loading a project, and subsequent saves will save to the same file (NOTE: The first time you save after loading you will be greeted with a permission dialog. This is demonstrated in the final GIF below

NOTE: One caveat on this. There is a little weirdness when using this in a browser tab and reloading the page with `?code` in the URL since we lose the file handle but retain the code. I'm not sure how to fix this. I prefer to use the app in an installed fashion so this didn't bother me.

Saving the project
==============
![cs-saving](https://user-images.githubusercontent.com/1614/101297319-06289880-37ee-11eb-80fc-4cedaebc01e6.gif)

Saving other file types
================
![cs-saving-other-files](https://user-images.githubusercontent.com/1614/101297321-088af280-37ee-11eb-8245-7f1f0f526597.gif)

Loading then saving
==============
![cs-loading-then-saving](https://user-images.githubusercontent.com/1614/101297324-0d4fa680-37ee-11eb-91db-d11da4f6ae17.gif)
