### PR TITLE
overload Difference so that you can separately choose to keep the mainObject and/or the objectsToSubtract

### DIFF
--- a/js/CADWorker/CascadeStudioStandardLibrary.js
+++ b/js/CADWorker/CascadeStudioStandardLibrary.js
@@ -482,10 +482,18 @@ function Difference(mainBody, objectsToSubtract, keepObjects, fuzzValue, keepEdg
     return difference;
   });
 
-  if (!keepObjects) { sceneShapes = Remove(sceneShapes, mainBody); }
-  for (let i = 0; i < objectsToSubtract.length; i++) {
-    if (!keepObjects) { sceneShapes = Remove(sceneShapes, objectsToSubtract[i]); }
+  if (Array.isArray(keepObjects)) {
+    if (!keepObjects[0]) { sceneShapes = Remove(sceneShapes, mainBody); }
+    for (let i = 0; i < objectsToSubtract.length; i++) {
+      if (!keepObjects[1]) { sceneShapes = Remove(sceneShapes, objectsToSubtract[i]); }
+    }
+  } else {
+    if (!keepObjects) { sceneShapes = Remove(sceneShapes, mainBody); }
+    for (let i = 0; i < objectsToSubtract.length; i++) {
+      if (!keepObjects) { sceneShapes = Remove(sceneShapes, objectsToSubtract[i]); }
+    }
   }
+
   sceneShapes.push(curDifference);
   return curDifference;
 }

--- a/js/StandardLibraryIntellisense.ts
+++ b/js/StandardLibraryIntellisense.ts
@@ -89,9 +89,10 @@ function Union(objectsToJoin: oc.TopoDS_Shape[], keepObjects?: boolean, fuzzValu
  * The original shapes are removed unless `keepObjects` is true.  Returns a Compound Shape unless onlyFirstSolid is true.
  * [Source](https://github.com/zalo/CascadeStudio/blob/master/js/CADWorker/CascadeStudioStandardLibrary.js)
  * @example```let floatingCorners = Difference(Box(50, 50, 50, true), [Sphere(38)]);```*/
-function Difference(mainBody: oc.TopoDS_Shape, objectsToSubtract: oc.TopoDS_Shape[], keepObjects?: boolean, fuzzValue?:number, keepEdges?: boolean): oc.TopoDS_Shape;
+function Difference(mainBody: oc.TopoDS_Shape, objectsToSubtract: oc.TopoDS_Shape[], keepObjects?: boolean | boolean[], fuzzValue?:number, keepEdges?: boolean): oc.TopoDS_Shape;
 /** Takes only the intersection of a list of shapes.
- * The original shapes are removed unless `keepObjects` is true.
+ * The original shapes are removed unless `keepObjects` is true. 
+ * `keepObjects` can also be a list [keepMainBody: boolean, keepObjectsToSubtract: boolean]
  * [Source](https://github.com/zalo/CascadeStudio/blob/master/js/CADWorker/CascadeStudioStandardLibrary.js)
  * @example```let roundedBox = Intersection([Box(50, 50, 50, true), Sphere(38)]);```*/
 function Intersection(objectsToIntersect: oc.TopoDS_Shape[], keepObjects?: boolean, fuzzValue?: number, keepEdges?: boolean): oc.TopoDS_Shape;


### PR DESCRIPTION
This small changes allows you to cut out the space from one object to fit another, whilst keeping two objects in the scene, rather than one or three. I found it useful for rebate joins in wood.

e.g.

`Difference(
    Box(10, 2, 10), 
    [Translate([4, 1, 0], Box(2, 10, 10))], 
    [false, true]
)`

![image](https://user-images.githubusercontent.com/589364/129562892-51853f83-1e28-470c-9387-9b30aadffe17.png)
