### PR TITLE
Avoid calling Reversed() when mirroring

### DIFF
--- a/js/CADWorker/CascadeStudioStandardLibrary.js
+++ b/js/CADWorker/CascadeStudioStandardLibrary.js
@@ -407,14 +407,13 @@ function Mirror(vector, shapes, keepOriginal) {
     const mirrorPlaneOrigin = new oc.gp_Pnt(0, 0, 0);
     const mirrorPlaneNormal = new oc.gp_Dir(vector[0], vector[1], vector[2]);
     mirrorTransform.SetMirror(new oc.gp_Ax2(mirrorPlaneOrigin, mirrorPlaneNormal));
-    const mirroring = new oc.TopLoc_Location(mirrorTransform);
 
     if (!isArrayLike(shapes)) {
-      return new oc.TopoDS_Shape(shapes.Moved(mirroring).Reversed());
+      return new oc.BRepBuilderAPI_Transform(shapes, mirrorTransform).Shape();
     } else if (shapes.length >= 1) {
       let newMirroring = [];
       for (let shapeIndex = 0; shapeIndex < shapes.length; shapeIndex++) {
-        newMirroring.push(new oc.TopoDS_Shape(shapes[shapeIndex].Moved(mirroring).Reversed()));
+        newMirroring.push(new oc.BRepBuilderAPI_Transform(shapes, mirrorTransform).Shape());
       }
       return newMirroring;
     }


### PR DESCRIPTION
`Mirror()` appears to work, but I think it's adding some weird reversing artifacts. 

It changes the face rendering in Three, may be causing some degenerate facets in exported STLs, and mirrored shapes can (but don't always) disappear when union-ing with non-reversed shapes if they had overlapping volumes instead of coplanar faces. :shrug: 

Using `BRepBuilderAPI_Transform` with the transform seems to both not require reversing, and leaves correctly facing faces that seem to union correctly.

[Example](https://zalo.github.io/CascadeStudio/#code=pVTdb9owEH%2Fnr7j2pYlK%2BShdH8ao1MKmIfUDFaY9IFR5yQUsjB3ZTqGa%2BN93dhIItHuYhhJyPt%2F9fvfhc7MJP1FEaoVgFfSZiViMMLZZzNUJAHxHjcDoNc4kM5hkApJMRpYraT7Xmk2AiWbSCGYxCOvwrGwhjSMmvPDAtVbaST8keTlhwJOEkGXkDYbSojboMYPQY96pjcdIF2TmpP6b4DJGD9NX0usmuLGdgZNGSrzNd85PSWLQOv3XjdVZXAksrmrwVYlXL4546r%2F3KvF%2BHuYbFwLt13iOxrMu2IqCLtfeZCx4GdMCo%2BWvPGoX11CmmYcaaJXGau1iq5WFg0dcF1V5pbSVroNZsBRNHZaI6ZPmcy6ZCOF3DYAnEJzkZqSAXIIeTNt1aNEz68KWzCLqh4WVR8WY9vssWuBTGjA9z1YoLYEHIfRuPOihve9govSK9D2QuAYVNebpy0SbJAi77%2BxHgknMozywH0kbtPKo%2Fub1SCxMHHgNeFmGaWtWLxKctvfi5axAO4q2MUZblHGPdru5DN5FWX8fQvhBhFzO95FNVHqvohd6mT%2BYR%2BTk7v19e7i51Zq93fMlBnknw7Cos%2FtptJmWJfDdM6Z3GRd0cm5Hw5cdYlCegWOmxthtlI3YAgqDnjd3aAiUc7uAmx6096x0dB3hQyWx6axbbBIsBM7CIwxpsDa03%2BpW11%2FgAL66d35eza7K0kgzswj%2BN9GwjHNbOy7gjqkoBv1vw3JKjoYHTIQSPaah9J5xpWjcK8py7MJ8hCo7eR7lNOW9LoIold3atlZzNbSEvb8Dpxef%2FARcubNc3FCn7LQOnWvSN9q0e0YXmFGCmTOXqYe4JIz9pbAb7TpYenSGYS2%2FO6duTfNQMHc%2BpL7%2BJ%2BorwviAt3NM7BRXjpkuvoGSZ9adorlDUOCqBXyVKk1XLNDhUtFFjAmXtMpLDFySXbUhtGRxDHaBKyfTF9ZKL03KIjz5Aw%3D%3D&gui=q1ZKzs8tyM9LzSvxS8xNVbJSSk4sTk5MSQ3LTC1X0lHyTS3OCEotVrIy0DPUUXJOTM5ItVeyKikqTdVRCkpMySwFShkb1AIA)