### PR TITLE
Resolving loading issue of Typescript Intellisense Definitions

### DIFF
--- a/js/CADWorker/CascadeStudioMainWorker.js
+++ b/js/CADWorker/CascadeStudioMainWorker.js
@@ -126,7 +126,7 @@ function combineAndRenderShapes(payload) {
       payload.maxDeviation||0.1, fullShapeEdgeHashes, fullShapeFaceHashes);
     sceneShapes = [];
     postMessage({ "type": "Progress", "payload": { "opNumber": opNumber, "opType": "" } }); // Finish the progress
-    return facesAndEdges;
+    return [facesAndEdges, payload.sceneOptions];
   } else {
     console.error("There were no scene shapes returned!");
   }

--- a/js/MainPage/CascadeMain.js
+++ b/js/MainPage/CascadeMain.js
@@ -217,6 +217,8 @@ function initialize(projectContent = null) {
                 messageHandlers["addButton"]({ name: "Evaluate", label: "Function", callback: () => { monacoEditor.evaluateCode(true) } });
                 messageHandlers["addSlider"]({ name: "MeshRes", default: 0.1, min: 0.01, max: 2, step: 0.01, dp: 2 });
                 messageHandlers["addCheckbox"]({ name: "Cache?", default: true });
+                messageHandlers["addCheckbox"]({ name: "GroundPlane?", default: true });
+                messageHandlers["addCheckbox"]({ name: "Grid?", default: true });
                 userGui = true;
                 // Remove any existing Transform Handles that could be laying around
                 threejsViewport.clearTransformHandles();
@@ -245,7 +247,8 @@ function initialize(projectContent = null) {
                 // and begin saving them out
                 cascadeStudioWorker.postMessage({
                     "type": "combineAndRenderShapes",
-                    payload: { maxDeviation: GUIState["MeshRes"] }
+		//TODO: GUIState[] wird bei übergabe evtl. referenziert und nicht kopiert (Checkboxen sind nach reload false obwohl standard true ist.)
+                    payload: { maxDeviation: GUIState["MeshRes"], sceneOptions: { groundPlaneVisible: GUIState["GroundPlane?"], gridVisible: GUIState["Grid?"] } }
                 });
 
                 // Saves the current code to the project

--- a/js/MainPage/CascadeMain.js
+++ b/js/MainPage/CascadeMain.js
@@ -113,25 +113,25 @@ function initialize(projectContent = null) {
 
             // Import Typescript Intellisense Definitions for the relevant libraries...
             var extraLibs = [];
-            let prefix = window.location.href.startsWith("https://zalo.github.io/") ? "/CascadeStudio" : "";
+            let prefix = window.location.href.startsWith("https://zalo.github.io/") ? "/CascadeStudio/" : "";
             // opencascade.js Typescript Definitions...
-            fetch(prefix + "/node_modules/opencascade.js/dist/oc.d.ts").then((response) => {
+            fetch(prefix + "node_modules/opencascade.js/dist/oc.d.ts").then((response) => {
                 response.text().then(function (text) {
-                    extraLibs.push({ content: text, filePath: 'file://' + prefix + '/node_modules/opencascade.js/dist/oc.d.ts' });
+                    extraLibs.push({ content: text, filePath: 'file://' + prefix + 'node_modules/opencascade.js/dist/oc.d.ts' });
                 });
             }).catch(error => console.log(error.message));
 
             // Three.js Typescript definitions...
-            fetch(prefix + "/node_modules/three/build/three.d.ts").then((response) => {
+            fetch(prefix + "node_modules/three/build/three.d.ts").then((response) => {
                 response.text().then(function (text) {
-                    extraLibs.push({ content: text, filePath: 'file://' + prefix + '/node_modules/three/build/three.d.ts' });
+                    extraLibs.push({ content: text, filePath: 'file://' + prefix + 'node_modules/three/build/three.d.ts' });
                 });
             }).catch(error => console.log(error.message));
 
             // CascadeStudio Typescript Definitions...
-            fetch(prefix + "/js/StandardLibraryIntellisense.ts").then((response) => {
+            fetch(prefix + "js/StandardLibraryIntellisense.ts").then((response) => {
                 response.text().then(function (text) {
-                    extraLibs.push({ content: text, filePath: 'file://' + prefix + '/js/StandardLibraryIntellisense.d.ts' });
+                    extraLibs.push({ content: text, filePath: 'file://' + prefix + 'js/StandardLibraryIntellisense.d.ts' });
                     monaco.editor.createModel("", "typescript"); //text
                     monaco.languages.typescript.typescriptDefaults.setExtraLibs(extraLibs);
                 });

--- a/js/MainPage/CascadeMain.js
+++ b/js/MainPage/CascadeMain.js
@@ -247,7 +247,7 @@ function initialize(projectContent = null) {
                 // and begin saving them out
                 cascadeStudioWorker.postMessage({
                     "type": "combineAndRenderShapes",
-		//TODO: GUIState[] wird bei übergabe evtl. referenziert und nicht kopiert (Checkboxen sind nach reload false obwohl standard true ist.)
+                // TODO: GUIState[] may be referenced upon transfer and not copied (checkboxes are false after reload although the default is true
                     payload: { maxDeviation: GUIState["MeshRes"], sceneOptions: { groundPlaneVisible: GUIState["GroundPlane?"], gridVisible: GUIState["Grid?"] } }
                 });
 

--- a/js/MainPage/CascadeView.js
+++ b/js/MainPage/CascadeView.js
@@ -51,25 +51,6 @@ var Environment = function (goldenContainer) {
     this.renderer.shadowMap.type       = THREE.PCFSoftShadowMap;
     //this.scene.add(new THREE.CameraHelper(this.light2.shadow.camera));
 
-    // Create the ground mesh
-    this.groundMesh = new THREE.Mesh(new THREE.PlaneBufferGeometry(2000, 2000),
-      new THREE.MeshPhongMaterial({
-        color: 0x080808, depthWrite: true, dithering: true,
-        polygonOffset: true, // Push the mesh back for line drawing
-        polygonOffsetFactor: 6.0, polygonOffsetUnits: 1.0
-      }));
-    this.groundMesh.position.y = -0.1;
-    this.groundMesh.rotation.x = - Math.PI / 2;
-    this.groundMesh.receiveShadow = true;
-    this.scene.add(this.groundMesh);
-
-    // Create the Ground Grid; one line every 100 units
-    this.grid = new THREE.GridHelper(2000, 20, 0xcccccc, 0xcccccc);
-    this.grid.position.y = -0.01;
-    this.grid.material.opacity = 0.3;
-    this.grid.material.transparent = true;
-    this.scene.add(this.grid);
-
     // Set up the orbit controls used for Cascade Studio
     this.controls = new THREE.OrbitControls(this.camera, this.renderer.domElement);
     this.controls.target.set(0, 45, 0);
@@ -132,12 +113,40 @@ var CascadeEnvironment = function (goldenContainer) {
                         });
 
   // A callback to load the Triangulated Shape from the Worker and add it to the Scene
-  messageHandlers["combineAndRenderShapes"] = ([facelist, edgelist]) => {
+  messageHandlers["combineAndRenderShapes"] = ([[facelist, edgelist],sceneOptions]) => {
     window.workerWorking = false;     // Untick this flag to allow Evaluations again
     if (!facelist) { return;}  // Do nothing if the results are null
 
     // The old mainObject is dead!  Long live the mainObject!
     this.environment.scene.remove(this.mainObject);
+
+    this.environment.scene.remove(this.groundMesh);
+    if (sceneOptions.groundPlaneVisible)
+	{
+	    // Create the ground mesh
+	    this.groundMesh = new THREE.Mesh(new THREE.PlaneBufferGeometry(2000, 2000),
+	      new THREE.MeshPhongMaterial({
+	        color: 0x080808, depthWrite: true, dithering: true,
+	        polygonOffset: true, // Push the mesh back for line drawing
+	        polygonOffsetFactor: 6.0, polygonOffsetUnits: 1.0
+	      }));
+	    this.groundMesh.position.y = -0.1;
+	    this.groundMesh.rotation.x = - Math.PI / 2;
+	    this.groundMesh.receiveShadow = true;
+	    this.environment.scene.add(this.groundMesh);
+	}
+
+        this.environment.scene.remove(this.grid);
+	if (sceneOptions.gridVisible)
+	{
+	    // Create the Ground Grid; one line every 100 units
+	    this.grid = new THREE.GridHelper(2000, 20, 0xcccccc, 0xcccccc);
+	    this.grid.position.y = -0.01;
+	    this.grid.material.opacity = 0.3;
+	    this.grid.material.transparent = true;
+	    this.environment.scene.add(this.grid);
+	}
+
     this.mainObject            = new THREE.Group();
     this.mainObject.name       = "shape";
     this.mainObject.rotation.x = -Math.PI / 2;
@@ -198,7 +207,7 @@ var CascadeEnvironment = function (goldenContainer) {
         lineVertices.push(new THREE.Vector3(edge.vertex_coord[i    ],
                                             edge.vertex_coord[i + 1],
                                             edge.vertex_coord[i + 2]));
-                  
+
         lineVertices.push(new THREE.Vector3(edge.vertex_coord[i     + 3],
                                             edge.vertex_coord[i + 1 + 3],
                                             edge.vertex_coord[i + 2 + 3]));


### PR DESCRIPTION
If no prefix is set, the Typescript definitions will be pulled with an absolute Path instead of the current subdir. So the Typescript definitions cannot be found on Servers othe than https://zalo.github.com/
Removed absolute path reference to resolve this issue.